### PR TITLE
Chore: Update pouchdb-promise dependency to fix 'Promise is not a con…

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "md5-jkmyers": "0.0.1",
     "pouchdb-extend": "^0.1.0",
     "pouchdb-mapreduce-no-ddocs": "^2.3.2",
-    "pouchdb-promise": "5.4.4",
+    "pouchdb-promise": "^6.3.4",
     "uniq": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
…structor' error in webpack build.